### PR TITLE
Nested reduce

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -377,12 +377,11 @@ private:
              "sizeInterWarps must be 2^m.");
       assert(threadsPerWarp > 1 &&
              "threadsPerWarp must be larger than 1 to do warp reduce.");
-
-      // It is a batched reduce with the initial problem shape [elems /
-      // sizeInterWarps, sizeInterWarps]. The threadsPerWarp is 2^n. The
-      // sizeInterWarps is 2^m. With the horizontal warp reduction, the problem
-      // size is [elems / sizeInterWarps, N] -> [elems / sizeInterWarps, ceil(N,
-      // threadsPerWarp)] in each reduce iteration.
+      // It is a batched reduction with the initial problem shape 
+      // [batch, sizeInterWarps]. The threadsPerWarp is 2^n. 
+      // The sizeInterWarps is 2^m. With the horizontal warp reduction, 
+      //the problem size becomes [batch, ceil(N / threadsPerWarp)] 
+      // from [batch, N] in each reduction iteration.
       unsigned problemBatchSize = elems / sizeInterWarps;
       for (unsigned problemSize = sizeInterWarps; problemSize > 0;
            problemSize = problemSize / threadsPerWarp) {

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -377,10 +377,10 @@ private:
              "sizeInterWarps must be 2^m.");
       assert(threadsPerWarp > 1 &&
              "threadsPerWarp must be larger than 1 to do warp reduce.");
-      // It is a batched reduction with the initial problem shape 
-      // [batch, sizeInterWarps]. The threadsPerWarp is 2^n. 
-      // The sizeInterWarps is 2^m. With the horizontal warp reduction, 
-      //the problem size becomes [batch, ceil(N / threadsPerWarp)] 
+      // It is a batched reduction with the initial problem shape
+      // [batch, sizeInterWarps]. The threadsPerWarp is 2^n.
+      // The sizeInterWarps is 2^m. With the horizontal warp reduction,
+      // the problem size becomes [batch, ceil(N / threadsPerWarp)]
       // from [batch, N] in each reduction iteration.
       unsigned problemBatchSize = elems / sizeInterWarps;
       for (unsigned problemSize = sizeInterWarps; problemSize > 0;

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -332,39 +332,113 @@ private:
     unsigned numThreads =
         product<unsigned>(triton::gpu::getWarpsPerCTA(srcLayout)) *
         triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
-    unsigned elemsPerThread = std::max<unsigned>(elems / numThreads, 1);
-    Value threadIsNeeded = icmp_slt(threadId, i32_val(elems));
-    Value readOffset = threadId;
-    for (unsigned round = 0; round < elemsPerThread; ++round) {
-      SmallVector<Value> acc(op.getNumOperands());
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        auto elemTy = getElementType(op, i);
-        Value readPtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
-                            smemBases[i], readOffset);
-        acc[i] = targetInfo.loadShared(rewriter, loc, getTypeConverter(),
-                                       readPtr, elemTy, threadIsNeeded);
-      }
-      warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */);
-      // only the first thread in each sizeInterWarps is writing
-      Value writeOffset = readOffset;
-      SmallVector<Value> writePtrs(op.getNumOperands());
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        auto elemTy = getElementType(op, i);
-        writePtrs[i] = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
-                           smemBases[i], writeOffset);
-      }
+    unsigned threadsPerWarp =
+        triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+    // single step reduction if sizeInterWarps <= #threads/warp
+    if (sizeInterWarps <= threadsPerWarp) {
+      unsigned elemsPerThread = std::max<unsigned>(elems / numThreads, 1);
+      Value threadIsNeeded = icmp_slt(threadId, i32_val(elems));
+      Value readOffset = threadId;
+      for (unsigned round = 0; round < elemsPerThread; ++round) {
+        SmallVector<Value> acc(op.getNumOperands());
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          auto elemTy = getElementType(op, i);
+          Value readPtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
+                              smemBases[i], readOffset);
+          acc[i] = targetInfo.loadShared(rewriter, loc, getTypeConverter(),
+                                         readPtr, elemTy, threadIsNeeded);
+        }
+        warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */);
+        // only the first thread in each sizeInterWarps is writing
+        Value writeOffset = readOffset;
+        SmallVector<Value> writePtrs(op.getNumOperands());
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          auto elemTy = getElementType(op, i);
+          writePtrs[i] = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
+                             smemBases[i], writeOffset);
+        }
 
-      Value laneIdModSizeInterWarps = urem(laneId, i32_val(sizeInterWarps));
-      Value laneIdModSizeInterWarpsIsZero =
-          icmp_eq(laneIdModSizeInterWarps, zero);
-      Value pred = and_(threadIsNeeded, laneIdModSizeInterWarpsIsZero);
+        Value laneIdModSizeInterWarps = urem(laneId, i32_val(sizeInterWarps));
+        Value laneIdModSizeInterWarpsIsZero =
+            icmp_eq(laneIdModSizeInterWarps, zero);
+        Value pred = and_(threadIsNeeded, laneIdModSizeInterWarpsIsZero);
 
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-        targetInfo.storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
+        for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+          targetInfo.storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
+        }
+
+        if (round != elemsPerThread - 1) {
+          readOffset = add(readOffset, i32_val(numThreads));
+        }
       }
+    } else { // perform batched reduction if reduction size > #threads/warp
+      // the algorithm only works when the interwarpsize is power of 2
+      assert(((sizeInterWarps - 1) & sizeInterWarps) == 0 &&
+             "sizeInterWarps must be 2^m.");
+      assert(threadsPerWarp > 1 &&
+             "threadsPerWarp must be larger than 1 to do warp reduce.");
 
-      if (round != elemsPerThread - 1) {
-        readOffset = add(readOffset, i32_val(numThreads));
+      // It is a batched reduce with the initial problem shape [elems /
+      // sizeInterWarps, sizeInterWarps]. The threadsPerWarp is 2^n. The
+      // sizeInterWarps is 2^m. With the horizontal warp reduction, the problem
+      // size is [elems / sizeInterWarps, N] -> [elems / sizeInterWarps, ceil(N,
+      // threadsPerWarp)] in each reduce iteration.
+      unsigned problemBatchSize = elems / sizeInterWarps;
+      for (unsigned problemSize = sizeInterWarps; problemSize > 0;
+           problemSize = problemSize / threadsPerWarp) {
+        unsigned reduceLaneNumber = std::min(problemSize, threadsPerWarp);
+        unsigned totalProblemSizePerIter = problemSize * problemBatchSize;
+        unsigned elemsPerThread =
+            mlir::ceil<unsigned>(totalProblemSizePerIter, numThreads);
+
+        // The problem stride in each iteration is [sizeInterWarps /
+        // problemSize]
+        Value readOffset = mul(threadId, i32_val(sizeInterWarps / problemSize));
+
+        for (unsigned round = 0; round < elemsPerThread; ++round) {
+          Value threadIsNeeded = icmp_slt(readOffset, i32_val(elems));
+
+          SmallVector<Value> acc(op.getNumOperands());
+          for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+            auto elemTy = getElementType(op, i);
+            Value readPtr = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
+                                smemBases[i], readOffset);
+            acc[i] = targetInfo.loadShared(rewriter, loc, getTypeConverter(),
+                                           readPtr, elemTy, threadIsNeeded);
+          }
+          warpReduce(rewriter, loc, acc, op, reduceLaneNumber,
+                     1 /* interleave */);
+
+          Value writeOffset = readOffset;
+          SmallVector<Value> writePtrs(op.getNumOperands());
+          for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+            auto elemTy = getElementType(op, i);
+            writePtrs[i] = gep(ptr_ty(rewriter.getContext(), 3), elemTy,
+                               smemBases[i], writeOffset);
+          }
+
+          // only the first thread in each reduceLaneNumber is writing
+          Value threadIdModSizeReduceLanes =
+              urem(threadId, i32_val(reduceLaneNumber));
+          Value threadIdModSizeReduceLanesIsZero =
+              icmp_eq(threadIdModSizeReduceLanes, zero);
+          Value pred = and_(threadIsNeeded, threadIdModSizeReduceLanesIsZero);
+
+          for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+            targetInfo.storeShared(rewriter, loc, writePtrs[i], acc[i], pred);
+          }
+
+          if (round != elemsPerThread - 1) {
+            readOffset =
+                add(readOffset,
+                    i32_val(numThreads * (sizeInterWarps / problemSize)));
+          }
+        }
+
+        if (problemSize > threadsPerWarp) {
+          // More reduce iteration required. Synchronize here.
+          sync(rewriter, loc, op);
+        }
       }
     }
   }

--- a/test/TritonGPU/reduce-op-lowering.mlir
+++ b/test/TritonGPU/reduce-op-lowering.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
 
-// COM: Tests reduction when threads_per_warp(=32) < num_warps(=64). This case coulc be supported in future GPU architectures.
+// COM: Tests reduction when threads_per_warp(=32) < num_warps(=64). This case could be supported in future GPU architectures.
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 : i32} {

--- a/test/TritonGPU/reduce-op-lowering.mlir
+++ b/test/TritonGPU/reduce-op-lowering.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
 
-// COM: Tests reduction when threads_per_warp(=16) < num_warps(=64). A possible case for Intel XPUs
+// COM: Tests reduction when threads_per_warp(=32) < num_warps(=64). This case coulc be supported in future GPU architectures.
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 : i32} {

--- a/test/TritonGPU/reduce-op-lowering.mlir
+++ b/test/TritonGPU/reduce-op-lowering.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
+
+// COM: Tests reduction when threads_per_warp(=16) < num_warps(=64). A possible case for Intel XPUs
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [64], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 64 : i32} {
+  // CHECK-LABEL: reduce_problem_size_64_threads_per_warp_32
+  tt.func @reduce_problem_size_64_threads_per_warp_32(%f : tensor<2048xi32, #blocked>) {
+
+  // 1st round intra-warp reduce
+  // CHECK: %{{.*}} = nvvm.redux.sync  add %{{.*}}, %{{.*}} : i32 -> i32
+
+
+  // 2nd round inter-warp reduce with problem size 64 with threads_per_warp 32
+  // CHECK nvvm.barrier0
+  // CHECK [[STRIDE_1:%.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT [[OFFSET_1:%.*]] = llvm.mul %{{.*}}, [[STRIDE_1]] : i32
+  // CHECK %{{.*}} = llvm.icmp "slt" [[OFFSET_1]], %{{.*}} : i32
+  // CHECK: %{{.*}} = nvvm.redux.sync  add %{{.*}}, %{{.*}} : i32 -> i32
+
+  // 3rd round inter-warp reduce with problem size 2 with threads_per_warp 32
+  // CHECK nvvm.barrier0
+  // CHECK [[STRIDE_2:%.*]] = llvm.mlir.constant(32 : i32) : i32
+  // CHECK-NEXT [[OFFSET_2:%.*]] = llvm.mul %{{.*}}, [[STRIDE_2]] : i32
+  // CHECK %{{.*}} = llvm.icmp "slt" [[OFFSET_1]], %{{.*}} : i32
+  // Because reduction size is 2, it performs single shuffle-and-add
+  // CHECK: [[SHUFFLE_1:%.*]] = nvvm.shfl.sync  bfly %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32 -> i32
+  // CHECK-NEXT %{{.*}} = llvm.add %{{.*}}, [[SHUFFLE_1]] : i32
+
+  // get final result
+  // CHECK nvvm.barrier0
+  // CHECK: [[FINAL_RESULT:%.*]] = llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+
+    %g = "tt.reduce" (%f) ({
+    ^bb0(%arg0: i32, %arg1: i32):
+      %add = arith.addi %arg0, %arg1 : i32
+      tt.reduce.return %add : i32
+    }) {axis = 0 : i32} : (tensor<2048xi32, #blocked>) -> i32
+    tt.return
+  }
+}


### PR DESCRIPTION
## Adding batched reduce algorithm to support #warps > #threads-per-warp

Currently, Triton's reduce op, especially `accumulatePartialReductions` function doesn't support the case when number of warps is greater than number of threads per warp.
Such cases don't happen in current NVIDIA GPUs (as the maximum CTA size is 1024 and the warp size is 32), but can happen in different GPU architectures when:
1) The warp size is smaller than 32 (Intel GPU supports this)
2) The CTA (or thread block) size is bigger than 1024

The modified function runs the warp reduction multiple times when the number of warps is bigger than the size of each warp.
The lit test in `tests/TritonGPU/reduce_op_lowering.mlir` checks if the lowering generates multiple partial reduction passes when the CTA size is 2048.
It will fall back to the previous implementation when #warps <= #threads-per-warp.

Co-authored-by: Chengjun Lu <chengjun.lu@intel.com>

### PR checklists:

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have used an LLM to copyedit my PR description and and code comments.

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added are "minimal" -- they contain only the
    instructions necessary to exercise the bug.  (Usually running Python code
    and using the instructions it generates is not minimal.)
